### PR TITLE
feat: StatefulWidgetからRiverpodを使った状態管理に変更

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+// Riverpod を使用するために必要なインポート
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// カウンターの状態を管理するStateProvider
+// StateProvider: シンプルな状態管理を行うProvider
+// int型の値を保持し、外部から読み取り・更新が可能
+// 初期値として0を設定
 final counterProvider = StateProvider<int>((ref) => 0);
 
 void main() {
   runApp(
+    // ProviderScope: アプリ全体でProviderを使用可能にするためのルートWidget
+    // すべてのProviderはこのScope内でのみ利用可能
     const ProviderScope(
       child: MyApp(),
     ),
@@ -27,14 +32,19 @@ class MyApp extends StatelessWidget {
   }
 }
 
+// ConsumerWidget: Providerを使用するためのWidget基底クラス
+// StatefulWidgetの代わりに使用し、WidgetRefを通じてProviderにアクセス可能
 class MyHomePage extends ConsumerWidget {
   const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
+  // build メソッドに WidgetRef が追加される
+  // WidgetRef: Providerとの橋渡しを行うオブジェクト
   Widget build(BuildContext context, WidgetRef ref) {
-    // counterProviderの値を監視
+    // ref.watch(): Providerの値を監視し、値が変更されると自動的にWidgetを再ビルド
+    // StateProviderの現在の値を取得
     final counter = ref.watch(counterProvider);
 
     return Scaffold(
@@ -48,7 +58,7 @@ class MyHomePage extends ConsumerWidget {
           children: <Widget>[
             const Text('You have pushed the button this many times:'),
             Text(
-              '$counter',
+              '$counter', // watchで取得した値を表示
               style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
@@ -56,7 +66,9 @@ class MyHomePage extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // StateProviderの値を更新
+          // ref.read(): Providerの値を一度だけ読み取り（監視しない）
+          // .notifier: StateProviderの状態を変更するためのNotifierを取得
+          // .state++: 状態を直接更新（自動的にリスナーに通知される）
           ref.read(counterProvider.notifier).state++;
         },
         tooltip: 'Increment',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+// カウンターの状態を管理するStateProvider
+final counterProvider = StateProvider<int>((ref) => 0);
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    const ProviderScope(
+      child: MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -19,30 +27,20 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends ConsumerWidget {
   const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    // counterProviderの値を監視
+    final counter = ref.watch(counterProvider);
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
+        title: Text(title),
       ),
       body: Center(
         child: Column(
@@ -50,14 +48,17 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             const Text('You have pushed the button this many times:'),
             Text(
-              '$_counter',
+              '$counter',
               style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
+        onPressed: () {
+          // StateProviderの値を更新
+          ref.read(counterProvider.notifier).state++;
+        },
         tooltip: 'Increment',
         child: const Icon(Icons.add),
       ),


### PR DESCRIPTION
## 概要
このPRでは、従来のStatefulWidgetを使った状態管理から、Riverpodを使った状態管理に変更しました。

## 変更内容
- StatefulWidgetからConsumerWidgetに変更
- ProviderScopeでアプリ全体をラップ
- StateProviderを使用してカウンター状態を管理
- 状態の監視と更新にref.watch()とref.read()を使用

## 使用したRiverpodの機能

### 1. ProviderScope
- **役割**: アプリ全体でProviderを使用可能にするルートWidget
- **使用箇所**: main()関数でMyAppをラップ
- **重要性**: すべてのProviderはこのScope内でのみ利用可能

### 2. StateProvider
- **役割**: シンプルな状態管理を行うProvider
- **特徴**: 
  - 単一の値を保持
  - 外部から読み取り・更新が可能
  - 状態変更時に自動的にリスナーに通知
- **使用例**: `final counterProvider = StateProvider<int>((ref) => 0);`

### 3. ConsumerWidget
- **役割**: Providerを使用するためのWidget基底クラス
- **StatefulWidgetとの違い**:
  - WidgetRefを通じてProviderにアクセス可能
  - 状態管理をWidget外で行える
  - より宣言的で保守しやすいコード

### 4. WidgetRef
- **役割**: Providerとの橋渡しを行うオブジェクト
- **主要メソッド**:
  - `ref.watch()`: Providerの値を監視し、変更時に自動再ビルド
  - `ref.read()`: Providerの値を一度だけ読み取り（監視しない）

### 5. StateProvider.notifier
- **役割**: StateProviderの状態を変更するためのNotifier
- **使用方法**: `ref.read(counterProvider.notifier).state++`
- **利点**: 状態変更が自動的に全てのリスナーに通知される

## 従来の実装との比較

### Before (StatefulWidget)
```dart
class _MyHomePageState extends State<MyHomePage> {
  int _counter = 0;
  
  void _incrementCounter() {
    setState(() {
      _counter++;
    });
  }
}
```

### After (Riverpod)
```dart
final counterProvider = StateProvider<int>((ref) => 0);

class MyHomePage extends ConsumerWidget {
  Widget build(BuildContext context, WidgetRef ref) {
    final counter = ref.watch(counterProvider);
    // ...
    onPressed: () => ref.read(counterProvider.notifier).state++,
  }
}
```

## Riverpodを使うメリット
1. **状態の分離**: UIロジックと状態管理の分離
2. **テスタビリティ**: Providerを独立してテスト可能
3. **再利用性**: 複数のWidgetで同じProviderを共有可能
4. **型安全性**: コンパイル時に型チェックが行われる
5. **デバッグ性**: 状態の変更履歴を追跡しやすい 